### PR TITLE
fix: make proxy work via CONNECT method

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,15 +42,18 @@
     "global-agent": "3.0.0",
     "leaky-bucket-queue": "0.0.2",
     "lodash": "4.17.21",
+    "proxy-from-env": "^1.1.0",
     "snyk-config": "^5.0.1",
     "source-map-support": "^0.5.16",
     "tslib": "^1.10.0",
     "uuid": "^8.0.0"
   },
   "devDependencies": {
+    "@types/global-agent": "^2.1.1",
     "@types/jest": "^25.1.1",
     "@types/lodash": "4.14.186",
     "@types/node": "^12.12.26",
+    "@types/proxy-from-env": "^1.0.2",
     "@typescript-eslint/eslint-plugin": "^2.18.0",
     "@typescript-eslint/parser": "^2.18.0",
     "eslint": "^6.8.0",


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [ ] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Adds relevant code and disables axios native broken proxy support to make request fly through proxy using the http CONNECT method.

### Notes for the reviewer

No change in functionality, just proper proxy support.
Not easy to setup proxy tests, so deferring that for later.
