### PR TITLE
fix: properly set rest api hostname

### DIFF
--- a/src/lib/request/request.ts
+++ b/src/lib/request/request.ts
@@ -6,7 +6,7 @@ import * as Error from '../customErrors/apiError';
 import { bootstrap } from 'global-agent';
 import { getProxyForUrl } from 'proxy-from-env';
 
-const DEFAULT_API = 'https://snyk.io/api/v1';
+const DEFAULT_API = 'https://api.snyk.io/v1';
 const DEFAULT_REST_API = 'https://api.snyk.io/rest/';
 interface SnykRequest {
   verb: string;

--- a/src/lib/request/requestManager.ts
+++ b/src/lib/request/requestManager.ts
@@ -37,9 +37,13 @@ interface RequestsManagerParams {
 
 function getRESTAPI(endpoint: string): string {
   // e.g 'https://api.snyk.io/rest/'
-  const apiData = new URL(endpoint.replace('app.', ''));
-
-  return new URL(`${apiData.protocol}//api.${apiData.host}/rest`).toString();
+  const apiData = new URL(endpoint);
+  if (!apiData.host.startsWith('api.') && process.env.NODE_ENV != 'test') {
+    console.warn(
+      `${apiData.host} seems invalid and should look like https://api.snyk.io or https://api.<REGION>.snyk.io.`,
+    );
+  }
+  return new URL(`${apiData.protocol}//${apiData.host}/rest`).toString();
 }
 
 const getConfig = (): { endpoint: string; token: string } => {

--- a/test/fixtures/apiResponses/general-doc.json
+++ b/test/fixtures/apiResponses/general-doc.json
@@ -1,5 +1,5 @@
 {
-    "what orgs can the current token access?": "https://snyk.io/api/v1/orgs",
-    "what projects are owned by this org?": "https://snyk.io/api/v1/org/:id/projects",
-    "test a package for issues": "https://snyk.io/api/v1/test/:packageManager/:packageName/:packageVersion"
+    "what orgs can the current token access?": "https://api.snyk.io/v1/orgs",
+    "what projects are owned by this org?": "https://api.snyk.io/v1/org/:id/projects",
+    "test a package for issues": "https://api.snyk.io/v1/test/:packageManager/:packageName/:packageVersion"
 }

--- a/test/lib/request/request.test.ts
+++ b/test/lib/request/request.test.ts
@@ -12,7 +12,7 @@ import {
 
 const fixturesFolderPath = path.resolve(__dirname, '../..') + '/fixtures/';
 beforeEach(() => {
-  return nock('https://snyk.io')
+  return nock('https://api.snyk.io')
     .persist()
     .get(/\/xyz/)
     .reply(404, '404')
@@ -40,7 +40,7 @@ beforeEach(() => {
     .post(/^(?!.*xyz).*$/)
     .reply(200, (uri, requestBody) => {
       switch (uri) {
-        case '/api/v1/':
+        case '/v1/':
           return requestBody;
           break;
         default:
@@ -49,7 +49,7 @@ beforeEach(() => {
     .get(/^(?!.*xyz).*$/)
     .reply(200, (uri) => {
       switch (uri) {
-        case '/api/v1/':
+        case '/v1/':
           return fs.readFileSync(
             fixturesFolderPath + 'apiResponses/general-doc.json',
           );

--- a/test/lib/requestManager/normal-flows.test.ts
+++ b/test/lib/requestManager/normal-flows.test.ts
@@ -10,7 +10,7 @@ import { RequestsManagerNotFoundError } from '../../../src/lib/customErrors/requ
 
 const fixturesFolderPath = path.resolve(__dirname, '../..') + '/fixtures/';
 beforeAll(() => {
-  return nock('https://snyk.io')
+  return nock('https://api.snyk.io')
     .persist()
     .get(/\/customtoken/)
     .reply(200, function() {
@@ -35,16 +35,16 @@ beforeAll(() => {
     .post(/^(?!.*xyz).*$/)
     .reply(200, (uri, requestBody) => {
       switch (uri) {
-        case '/api/v1/':
+        case '/v1/':
           return requestBody;
-        case '/api/v1/org/334e0c45-5d3d-40f6-b882-ae82a164b317/project/0bbbfee1-2138-4322-80d4-4166d1259ae5/issues':
+        case '/v1/org/334e0c45-5d3d-40f6-b882-ae82a164b317/project/0bbbfee1-2138-4322-80d4-4166d1259ae5/issues':
           return fs.readFileSync(
             fixturesFolderPath + 'apiResponses/projectIssues.json',
           );
         default:
       }
     })
-    .get(/\/api\/v1\/dummypath/)
+    .get(/\/v1\/dummypath/)
     .delay(1000)
     .reply(200, () => {
       return 'dummypath slowed down';
@@ -52,7 +52,7 @@ beforeAll(() => {
     .get(/^(?!.*xyz).*$/)
     .reply(200, (uri) => {
       switch (uri) {
-        case '/api/v1/':
+        case '/v1/':
           return fs.readFileSync(
             fixturesFolderPath + 'apiResponses/general-doc.json',
           );
@@ -188,11 +188,11 @@ describe('Testing Request Flows', () => {
     const expectedResponse = [
       {
         'what orgs can the current token access?':
-          'https://snyk.io/api/v1/orgs',
+          'https://api.snyk.io/v1/orgs',
         'what projects are owned by this org?':
-          'https://snyk.io/api/v1/org/:id/projects',
+          'https://api.snyk.io/v1/org/:id/projects',
         'test a package for issues':
-          'https://snyk.io/api/v1/test/:packageManager/:packageName/:packageVersion',
+          'https://api.snyk.io/v1/test/:packageManager/:packageName/:packageVersion',
       },
 
       'dummypath slowed down',
@@ -300,7 +300,7 @@ describe('Test getConfig function', () => {
   });
 
   it('Get snyk.io api endpoint default', async () => {
-    expect(getConfig().endpoint).toEqual('https://snyk.io/api/v1');
+    expect(getConfig().endpoint).toEqual('https://api.snyk.io/v1');
   });
 
   it('Get snyk api endpoint via env var', async () => {

--- a/test/lib/requestManager/rate-limits.test.ts
+++ b/test/lib/requestManager/rate-limits.test.ts
@@ -5,7 +5,7 @@ import * as path from 'path';
 
 const fixturesFolderPath = path.resolve(__dirname, '../..') + '/fixtures/';
 beforeAll(() => {
-  return nock('https://snyk.io')
+  return nock('https://api.snyk.io')
     .persist()
     .get(/\/xyz/)
     .reply(404, '404')
@@ -26,16 +26,16 @@ beforeAll(() => {
     .post(/^(?!.*xyz).*$/)
     .reply(200, (uri, requestBody) => {
       switch (uri) {
-        case '/api/v1/':
+        case '/v1/':
           return requestBody;
-        case '/api/v1/org/334e0c45-5d3d-40f6-b882-ae82a164b317/project/0bbbfee1-2138-4322-80d4-4166d1259ae5/issues':
+        case '/v1/org/334e0c45-5d3d-40f6-b882-ae82a164b317/project/0bbbfee1-2138-4322-80d4-4166d1259ae5/issues':
           return fs.readFileSync(
             fixturesFolderPath + 'apiResponses/projectIssues.json',
           );
         default:
       }
     })
-    .get(/\/api\/v1\/dummypath/)
+    .get(/\/v1\/dummypath/)
     .delay(1000)
     .reply(200, () => {
       return 'dummypath slowed down';
@@ -43,7 +43,7 @@ beforeAll(() => {
     .get(/^(?!.*xyz).*$/)
     .reply(200, (uri) => {
       switch (uri) {
-        case '/api/v1/':
+        case '/v1/':
           return fs.readFileSync(
             fixturesFolderPath + 'apiResponses/general-doc.json',
           );

--- a/test/lib/requestManager/retries.test.ts
+++ b/test/lib/requestManager/retries.test.ts
@@ -10,10 +10,10 @@ const requestManager = new requestsManager();
 
 describe('Testing Request Retries', () => {
   it('Retry on 500 - success after 1 retry', async () => {
-    nock('https://snyk.io')
+    nock('https://api.snyk.io')
       .post(/\/apierror/)
       .reply(500, '500');
-    nock('https://snyk.io')
+    nock('https://api.snyk.io')
       .post(/\/apierror/)
       .reply(200, () => {
         return fs.readFileSync(
@@ -39,19 +39,19 @@ describe('Testing Request Retries', () => {
   });
 
   it('Retry on 500 - success after 4 retries', async () => {
-    nock('https://snyk.io')
+    nock('https://api.snyk.io')
       .post(/\/apierror/)
       .reply(500, '500');
-    nock('https://snyk.io')
+    nock('https://api.snyk.io')
       .post(/\/apierror/)
       .reply(500, '500');
-    nock('https://snyk.io')
+    nock('https://api.snyk.io')
       .post(/\/apierror/)
       .reply(500, '500');
-    nock('https://snyk.io')
+    nock('https://api.snyk.io')
       .post(/\/apierror/)
       .reply(500, '500');
-    nock('https://snyk.io')
+    nock('https://api.snyk.io')
       .post(/\/apierror/)
       .reply(200, () => {
         return fs.readFileSync(
@@ -78,22 +78,22 @@ describe('Testing Request Retries', () => {
 
   it('Retry on 500 - fail after 5 retries', async () => {
     let hasReached5thTime = false;
-    nock('https://snyk.io')
+    nock('https://api.snyk.io')
       .post(/\/apierror/)
       .reply(500, '500');
-    nock('https://snyk.io')
+    nock('https://api.snyk.io')
       .post(/\/apierror/)
       .reply(500, '500');
-    nock('https://snyk.io')
+    nock('https://api.snyk.io')
       .post(/\/apierror/)
       .reply(500, '500');
-    nock('https://snyk.io')
+    nock('https://api.snyk.io')
       .post(/\/apierror/)
       .reply(500, '500');
-    nock('https://snyk.io')
+    nock('https://api.snyk.io')
       .post(/\/apierror/)
       .reply(500, '500');
-    nock('https://snyk.io')
+    nock('https://api.snyk.io')
       .post(/\/apierror/)
       .reply(500, () => {
         hasReached5thTime = true;


### PR DESCRIPTION
- [ ] Tests written and linted [ℹ︎](https://github.com/snyk/general/wiki/Tests)
- [ ] Documentation written [ℹ︎](https://github.com/snyk/general/wiki/Documentation)
- [x] Commit history is tidy [ℹ︎](https://github.com/snyk/general/wiki/Git)

### What this does

Resolves the api hostname across regions properly since Snyk standardized on api.<REGION>.snyk.io.